### PR TITLE
Add tests to check email using Gmail

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,12 @@
 USER_ID = 'standard_user'
 PASSWORD = 'secret_sauce'
+
+# Gmail API credentials for accessing Gmail inbox.
+# This may need to get recreated if the access token expires.
+# If this is the case, go here and add a new OAuth 2.0 Client ID with Type: Desktop app:
+# https://console.cloud.google.com/apis/credentials?inv=1&invt=Ab3fGg&project=playwright-gmail-api-project
+# For a more complete guide, see: https://hackernoon.com/how-to-read-gmail-emails-with-playwright
+GMAIL_CLIENT_ID = 'REPLACE_ME'
+GMAIL_CLIENT_SECRET = 'REPLACE_ME'
+# The refresh token may need to be regenerated if it expires, revoked, or if the client secret changes.
+GMAIL_REFRESH_TOKEN = 'REPLACE_ME'

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules/
 /playwright/.cache/
 /screenshots/
 
+credentials.json
 .DS_Store
 .history
 .todo

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ $ npx playwright test --project=<project_name>
 
 ## Email tests
 ### Gmail
-To run the tests for Gmail, it will require some setup. Follow the steps [here](https://hackernoon.com/how-to-read-gmail-emails-with-playwright) to obtain a `credentials.json` file and to use that to create a `client_id`, `client_secret`, and a `refresh_token`.
+All of these tests are marked to `skip` because the credentials are not setup. To set up proper credentials, follow the steps [here](https://hackernoon.com/how-to-read-gmail-emails-with-playwright) to obtain a `credentials.json` file and to use that to create a `client_id`, `client_secret`, and a `refresh_token`.
 
 These values will need to be inserted into the `.env` file.
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ To set up this project:
      ```
    * `faker-js`:
      ```
-     npm i @fakerjs/faker`
+     npm i @fakerjs/faker
      ```
 4. Install all the npm dependencies:
    ```

--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ To execute a specific project, run:
 $ npx playwright test --project=<project_name>
 ```
 
+## Email tests
+### Gmail
+To run the tests for Gmail, it will require some setup. Follow the steps [here](https://hackernoon.com/how-to-read-gmail-emails-with-playwright) to obtain a `credentials.json` file and to use that to create a `client_id`, `client_secret`, and a `refresh_token`.
+
+These values will need to be inserted into the `.env` file.
+
 # Test Report
 The test execution report can be viewed with:
 ```

--- a/helpers/gmail_helper.ts
+++ b/helpers/gmail_helper.ts
@@ -1,0 +1,11 @@
+import { getAccessToken } from 'gmail-getter';
+
+export default async function createAccessToken() {
+  const accessToken = await getAccessToken(
+    process.env.GMAIL_CLIENT_ID!,
+    process.env.GMAIL_CLIENT_SECRET!,
+    process.env.GMAIL_REFRESH_TOKEN!
+  );
+  
+  return accessToken;
+}

--- a/helpers/gmail_helper.ts
+++ b/helpers/gmail_helper.ts
@@ -1,11 +1,11 @@
 import { getAccessToken } from 'gmail-getter';
 
-export default async function createAccessToken() {
+export default async function getGmailAccessToken() {
   const accessToken = await getAccessToken(
     process.env.GMAIL_CLIENT_ID!,
     process.env.GMAIL_CLIENT_SECRET!,
     process.env.GMAIL_REFRESH_TOKEN!
   );
-  
+
   return accessToken;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "ISC",
       "dependencies": {
         "@faker-js/faker": "^9.9.0",
-        "dotenv": "^16.5.0"
+        "dotenv": "^16.5.0",
+        "gmail-getter": "^2.3.0"
       },
       "devDependencies": {
         "@playwright/test": "^1.53.1",
@@ -31,6 +32,21 @@
       "engines": {
         "node": ">=18.0.0",
         "npm": ">=9.0.0"
+      }
+    },
+    "node_modules/@google-cloud/local-auth": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@google-cloud/local-auth/-/local-auth-3.0.1.tgz",
+      "integrity": "sha512-YJ3GFbksfHyEarbVHPSCzhKpjbnlAhdzg2SEf79l6ODukrSM1qUOqfopY232Xkw26huKSndyzmJz+A6b2WYn7Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "arrify": "^2.0.1",
+        "google-auth-library": "^9.0.0",
+        "open": "^7.0.3",
+        "server-destroy": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@playwright/test": {
@@ -59,6 +75,127 @@
         "undici-types": "~7.8.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/arrify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.10.0.tgz",
+      "integrity": "sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/dotenv": {
       "version": "16.5.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
@@ -69,6 +206,116 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fsevents": {
@@ -84,6 +331,339 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gmail-getter": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/gmail-getter/-/gmail-getter-2.3.0.tgz",
+      "integrity": "sha512-A2nkNjuhsq7uh4CHZqrKY7lE5zYVP5UdaREOChXhApfrpJnH7l3bnsvxNVlPTo7qDzjiG7aqJ/7mbeKgPgmjzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@google-cloud/local-auth": "^3.0.1",
+        "axios": "^1.9.0"
+      },
+      "bin": {
+        "get-refresh-token": "dist/get-token-script.js"
+      }
+    },
+    "node_modules/google-auth-library": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gtoken": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+      "license": "MIT",
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
+      "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.0",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/open": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/playwright": {
@@ -118,12 +698,79 @@
         "node": ">=18"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/server-destroy": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/server-destroy/-/server-destroy-1.0.1.tgz",
+      "integrity": "sha512-rb+9B5YBIEzYcD6x2VKidaa+cqYBJQKnU4oe4E3ANwRRN56yk/ua1YCJT1n21NTS8w6CcOclAKNP3PhdCXKYtQ==",
+      "license": "ISC"
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/undici-types": {
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
       "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@faker-js/faker": "^9.9.0",
-    "dotenv": "^16.5.0"
+    "dotenv": "^16.5.0",
+    "gmail-getter": "^2.3.0"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -48,6 +48,10 @@ export default defineConfig({
       
     },
     {
+      name: 'email-tests',
+      testMatch: /emails\.spec\.ts/
+    },
+    {
       name: 'end-to-end-tests',
       testMatch: /end-to-end\.spec\.ts/,
 

--- a/tests/emails.spec.ts
+++ b/tests/emails.spec.ts
@@ -1,16 +1,16 @@
 import { test, expect } from '@playwright/test';
-import { checkInbox, parseHtmlFromEmail } from 'gmail-getter';
-import createAccessToken from '../helpers/gmail_helper';
+import { checkInbox, fetchEmailsList, fetchEmailById, parseHtmlFromEmail } from 'gmail-getter';
+import getGmailAccessToken from '../helpers/gmail_helper';
 
 test.describe('email', async () => {
   test.describe('gmail', async () => {
-    let accessToken: string | undefined,
+    let accessToken: string,
         fromEmail: string,
         subject: string,
         queryString: string;
 
     test.beforeAll(async () => {
-      accessToken = await createAccessToken();
+      accessToken = await getGmailAccessToken();
     });
 
     test('check inbox - find by query string', async ({ page }) => {
@@ -31,7 +31,54 @@ test.describe('email', async () => {
       const email = await checkInbox({ token: accessToken!, query: queryString });
       const html = parseHtmlFromEmail(email!);
       await page.setContent(html);
+
+      // TODO: Add assertions to verify the email content.
+      // For example, check if the email contains a specific text.
     });
+
+    test('get email list', async () => {
+      console.log('get email list test');
+
+      const emailList = await fetchEmailsList({ token: accessToken });
+      expect(emailList).toBeDefined();
+      expect(emailList.length).toBeGreaterThan(0);
+
+      /* Returns:
+      Email list: [
+        { id: '192e08ab5bbf519a', threadId: '192e08ab5bbf519a' },
+        { id: '18f53be23e78c08b', threadId: '18f53be23e78c08b' }
+      ]
+      */
+
+      // for (const email of emailList) {
+      //   expect(email.id).toBeDefined();
+      //   expect(email.threadId).toBeDefined();
+      //   console.log(`Email ID: ${email.id}, Snippet: ${email.threadId}`);
+      // }
+      /* Returns:
+      Email ID: 192e08ab5bbf519a, Snippet: 192e08ab5bbf519a
+      Email ID: 18f53be23e78c08b, Snippet: 18f53be23e78c08b
+      */
+    });
+
+    test('get email by id', async () => {
+      console.log('get email by id test');
+
+      const emailList = await fetchEmailsList({ token: accessToken });
+      expect(emailList).toBeDefined();
+      expect(emailList.length).toBeGreaterThan(0);
+
+      const emailId = emailList[0].id;
+
+      const email = await fetchEmailById(emailId, accessToken);
+      expect(email).toBeDefined();
+      expect(email.id).toBe(emailId);
+    });
+
+    test('delete email by id', async () => {
+      console.log('delete email by id test');
+      // TODO: Create a test to delete email by id.
+      //       This includes creating an email, fetching its ID, and then deleting it.
   });
 });
 
@@ -39,30 +86,6 @@ test.describe('email', async () => {
 
 // Everything below will eventually be deleted.
 /*
-
-    test('get email based on query string', async ({ page }) => {
-      // Google documentation on refining search results:
-      // https://support.google.com/mail/answer/7190#
-      let queryString = 'Automation Test Email';
-      let messageId, parsedMessageId, messageBody, parsedEmail;
-
-      email = new Email();
-
-      messageId = await email.getMessageId(accessToken, queryString);
-      parsedMessageId = JSON.parse(messageId);
-
-      messageBody = await email.getEmailMessage(accessToken, parsedMessageId);
-
-      console.log('messageId = ' + messageId);
-      console.log('parsedMessageId ' + parsedMessageId);
-
-      parsedEmail = await email.parseEmailIntoHtml(messageBody);
-      await page.setContent(parsedEmail);
-
-      // await email.assertOrderNumber('Order Number: 40023032');
-      await expect(page.locator('div.WordSection1')).toContainText('Order Number: 24680');
-    })
-
     test('delete based on queryString', async ({ request }) => {
       email = new Email();
 

--- a/tests/emails.spec.ts
+++ b/tests/emails.spec.ts
@@ -1,0 +1,94 @@
+import { test, expect } from '@playwright/test';
+import { checkInbox, parseHtmlFromEmail } from 'gmail-getter';
+import createAccessToken from '../helpers/gmail_helper';
+
+test.describe('email', async () => {
+  test.describe('gmail', async () => {
+    let accessToken: string | undefined,
+        fromEmail: string,
+        subject: string,
+        queryString: string;
+
+    test.beforeAll(async () => {
+      accessToken = await createAccessToken();
+    });
+
+    test('check inbox - find by query string', async ({ page }) => {
+      console.log('gmail - check inbox test');
+
+      // NOTE: I am unsure how fromEmail is used in the queryString.
+      //       'peter' returns the first email (even though both names are 'peter hong' or 'Peter Hong').
+      //       The email address is 'pshong@domain.com`.
+      //       'peterh' returns the second email - the email address is 'peterh@domain.com'.
+      fromEmail = 'peterh';
+      // fromEmail = 'pshong@gmail.com';
+
+      // NOTE: The subject does not seem to be used in the queryString.
+      // subject = 'Automation Test Email';
+      // queryString = `from:${fromEmail} subject:${subject}`;
+      queryString = `from:${fromEmail}`;
+
+      const email = await checkInbox({ token: accessToken!, query: queryString });
+      const html = parseHtmlFromEmail(email!);
+      await page.setContent(html);
+    });
+  });
+});
+
+
+
+// Everything below will eventually be deleted.
+/*
+
+    test('get email based on query string', async ({ page }) => {
+      // Google documentation on refining search results:
+      // https://support.google.com/mail/answer/7190#
+      let queryString = 'Automation Test Email';
+      let messageId, parsedMessageId, messageBody, parsedEmail;
+
+      email = new Email();
+
+      messageId = await email.getMessageId(accessToken, queryString);
+      parsedMessageId = JSON.parse(messageId);
+
+      messageBody = await email.getEmailMessage(accessToken, parsedMessageId);
+
+      console.log('messageId = ' + messageId);
+      console.log('parsedMessageId ' + parsedMessageId);
+
+      parsedEmail = await email.parseEmailIntoHtml(messageBody);
+      await page.setContent(parsedEmail);
+
+      // await email.assertOrderNumber('Order Number: 40023032');
+      await expect(page.locator('div.WordSection1')).toContainText('Order Number: 24680');
+    })
+
+    test('delete based on queryString', async ({ request }) => {
+      email = new Email();
+
+    let authToken = process.env.GMAIL_AUTH_TOKEN;
+    let emailList;
+    let queryString = 'Some string';
+    const listOfEmailIDs = [];
+
+    emailList = await email.getEmailList(accessToken, queryString);
+    // console.log('emailList = ' + JSON.stringify(emailList));
+    for (let i=0; i < emailList.messages.length; i++) {
+      listOfEmailIDs.push(emailList.messages[i].id);
+    }
+    // console.log('listOfEmailIDs = ' + listOfEmailIDs);
+
+    const responseBody = await request.post("https://gmail.googleapis.com/gmail/v1/users/peterh.emergent@gmail.com/messages/batchDelete", {
+      headers: {
+        // Token was created using Postman and copied here
+        "Authorization": authToken
+      },
+      data: {
+        "ids": listOfEmailIDs
+      }
+    });
+    await expect(responseBody.status()).toBe(204);
+    })
+  })
+})
+*/

--- a/tests/emails.spec.ts
+++ b/tests/emails.spec.ts
@@ -13,7 +13,7 @@ test.describe('email', async () => {
       accessToken = await getGmailAccessToken();
     });
 
-    test('check inbox - find by query string', async ({ page }) => {
+    test.skip('check inbox - find by query string', async ({ page }) => {
       console.log('gmail - check inbox test');
 
       // NOTE: I am unsure how fromEmail is used in the queryString.
@@ -36,7 +36,7 @@ test.describe('email', async () => {
       // For example, check if the email contains a specific text.
     });
 
-    test('get email list', async () => {
+    test.skip('get email list', async () => {
       console.log('get email list test');
 
       const emailList = await fetchEmailsList({ token: accessToken });
@@ -61,7 +61,7 @@ test.describe('email', async () => {
       */
     });
 
-    test('get email by id', async () => {
+    test.skip('get email by id', async () => {
       console.log('get email by id test');
 
       const emailList = await fetchEmailsList({ token: accessToken });
@@ -75,7 +75,7 @@ test.describe('email', async () => {
       expect(email.id).toBe(emailId);
     });
 
-    test('delete email by id', async () => {
+    test.skip('delete email by id', async () => {
       console.log('delete email by id test');
       // TODO: Create a test to delete email by id.
       //       This includes creating an email, fetching its ID, and then deleting it.

--- a/tests/emails.spec.ts
+++ b/tests/emails.spec.ts
@@ -79,6 +79,7 @@ test.describe('email', async () => {
       console.log('delete email by id test');
       // TODO: Create a test to delete email by id.
       //       This includes creating an email, fetching its ID, and then deleting it.
+    });
   });
 });
 


### PR DESCRIPTION
# Description
This change contains examples that uses Gmail to check emails. The examples contained here configures the tests to be able to authenticate and check the Gmail inbox using the `gmail-getter` library.

The actual `credentials.json` file and the `client_id`, 'client_secret', and 'refresh_token` stored in the `.env` file were not pushed into the repository. Those will need to be created before `emails.spec.ts` will successfully execute. Currently, they are set to skip the tests in the file.